### PR TITLE
Fix encoding setting for .d files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
   "publisher": "Kirides",
   "activationEvents": [],
   "contributes": {
-    "configurationDefaults": {
-      "[daedalus]": {
-        "files.encoding": "windows1252"
-      }
-    },
     "configuration": {
       "type": "object",
       "title": "Daedalus",
@@ -36,6 +31,7 @@
             "Windows-1251",
             "Windows-1252"
           ],
+          "markdownEnumDescriptions": ["Windows-1250 (Czech, Polish, Hungarian, Romanian)" , "Windows-1251 (Russian, Ukrainian)", "Windows-1252 (German, English, French, Italian, Spanish)"],
           "markdownDescription": "file encoding for `*.d` files"
         },
         "daedalusLanguageServer.srcFileEncoding": {


### PR DESCRIPTION
Currently if you want to use other encoding than `windows1252`  following lines have to be added to settings.json manually:
```json
    "[daedalus]": {
        "files.encoding": "windows125X"
    },
```
So i changed extension it to do this automatically when `daedalusLanguageServer.fileEncoding` is changed.