### PR TITLE
Fix Daedalus document synchronization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-daedalus",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-daedalus",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   "displayName": "Daedalus (Gothic/II)",
   "homepage": "https://github.com/kirides/vscode-daedalus",
   "license": "MIT",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "engines": {
     "vscode": ">=1.97.0"
   },
-  "publisher": "Kirides",
-  "activationEvents": [],
+  "publisher": "kirides",
+  "activationEvents": [
+    "onLanguage:daedalus"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",
@@ -113,8 +115,8 @@
           "daedalus"
         ],
         "extensions": [
-          "d",
-          "D"
+          ".d",
+          ".D"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -125,8 +127,8 @@
           "modelscript"
         ],
         "extensions": [
-          "mds",
-          "MDS"
+          ".mds",
+          ".MDS"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,18 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { ServerOptions, LanguageClient, LanguageClientOptions } from 'vscode-languageclient/lib/node/main'
+import type { DocumentSelector } from 'vscode-languageserver-protocol'
 import { Trace } from 'vscode-jsonrpc';
 import { log } from 'console';
 import { execFileSync } from 'child_process';
 
 const LANGUAGE: string = "daedalus";
+const DOCUMENT_SELECTOR: DocumentSelector = [
+	{ scheme: 'file', language: LANGUAGE },
+	{ scheme: 'file', pattern: '**/*.d' },
+	{ scheme: 'file', pattern: '**/*.D' }
+];
+
 interface Dictionary<T> {
     [Key: string]: T;
 }
@@ -66,6 +73,22 @@ function updateFileEncoding() {
 
 export function activate(context: vscode.ExtensionContext) {
 	const lspPath = path.join(context.extensionPath, 'languageserver');
+	const syncedDocumentVersions = new Map<string, number>();
+	let client: LanguageClient | undefined;
+
+	async function syncDocumentBeforeFeatureRequest(document: vscode.TextDocument, token: vscode.CancellationToken) {
+		if (token.isCancellationRequested || document.uri.scheme !== 'file' || !client) {
+			return;
+		}
+
+		const uri = document.uri.toString();
+		if (syncedDocumentVersions.get(uri) === document.version) {
+			return;
+		}
+
+		await client.sendNotification('textDocument/didOpen', client.code2ProtocolConverter.asOpenTextDocumentParams(document));
+		syncedDocumentVersions.set(uri, document.version);
+	}
 	
 	const lookup : Dictionary<string> = {
 		"linux-x32": 'DaedalusLanguageServer.x86',
@@ -101,16 +124,24 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
-		// Register the server for plain text documents
-		documentSelector: [
-			{ language: LANGUAGE, },
-			{ pattern: '**/*.d', },
-			{ pattern: '**/*.D', }
-		],
+		// Register the server for Daedalus documents
+		documentSelector: DOCUMENT_SELECTOR,
 		synchronize: {
 			configurationSection: 'daedalusLanguageServer',
 		},
 		middleware: {
+			async provideDocumentSemanticTokens(document, token, next) {
+				await syncDocumentBeforeFeatureRequest(document, token);
+				return next(document, token);
+			},
+			async provideDocumentRangeSemanticTokens(document, range, token, next) {
+				await syncDocumentBeforeFeatureRequest(document, token);
+				return next(document, range, token);
+			},
+			async provideInlayHints(document, viewPort, token, next) {
+				await syncDocumentBeforeFeatureRequest(document, token);
+				return next(document, viewPort, token);
+			},
 			async provideCodeLenses(document, token, next) {
 				const ret = await next(document, token);
 				ret?.map(lens => mapLensFromLspToVscode(lens));
@@ -124,12 +155,15 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	// Create the language client and start the client.
-	const client = new LanguageClient('daedalusLanguageServer', 'Daedalus Language Server', serverOptions, clientOptions);
+	client = new LanguageClient('daedalusLanguageServer', 'Daedalus Language Server', serverOptions, clientOptions);
 	client.setTrace(Trace.Verbose);
 	client.start();
 
 	context.subscriptions.push(
 		client,
+		vscode.workspace.onDidCloseTextDocument(document => {
+			syncedDocumentVersions.delete(document.uri.toString());
+		}),
 	);
 
 	// Update file encoding and add listen for changes


### PR DESCRIPTION
Fixes document sync issues in newer VS Code versions where semantic tokens and inlay hints can be requested for `.d` files before the language server has a matching text document buffer.

Changes:
- Register contributed file extensions with leading dots (`.d`, `.D`, `.mds`, `.MDS`)
- Activate explicitly on Daedalus language files
- Reuse a shared document selector
- Ensure semantic token and inlay hint requests sync the current document before forwarding the request to the server
- Bump package version to `0.0.27`

Verified with:
- `npm run compile`
- `npm run webpack`
